### PR TITLE
Add license header into `jq.py/07_non_existing_key.py`

### DIFF
--- a/jq.py/07_non_existing_key.py
+++ b/jq.py/07_non_existing_key.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
 # vim: set fileencoding=utf-8
 
+#
+#  (C) Copyright 2018  Pavel Tisnovsky
+#
+#  All rights reserved. This program and the accompanying materials
+#  are made available under the terms of the Eclipse Public License v1.0
+#  which accompanies this distribution, and is available at
+#  http://www.eclipse.org/legal/epl-v10.html
+#
+#  Contributors:
+#      Pavel Tisnovsky
+#
+
 #  Demonstrační příklad k článku:
 #      Zpracování dat uložených ve formátu JSON knihovnou jq.py
 


### PR DESCRIPTION
Add license header into `jq.py/07_non_existing_key.py`

Fixes #66